### PR TITLE
dashboard for pending datasets - fixes #17

### DIFF
--- a/bin/travis-install-dependencies
+++ b/bin/travis-install-dependencies
@@ -50,15 +50,21 @@ python setup.py develop
 pip install -r requirements.txt
 cd -
 
+git clone https://github.com/ckan/ckanext-showcase
+cd ckanext-showcase
+python setup.py develop
+pip install -r requirements.txt
+cd -
+
 echo "Installing ckanext-ed and its requirements..."
 python setup.py develop
 
-# Change the path the core test ini file as the docker compose scripts change this 
-# locally 
-sed -i -e 's/config:..\/..\/src\/ckan\/test-core.ini/config:..\/ckan\/test-core.ini/' test.ini 
- 
-echo "Moving test.ini into a subdir..." 
-mkdir subdir 
-mv test.ini subdir 
+# Change the path the core test ini file as the docker compose scripts change this
+# locally
+sed -i -e 's/config:..\/..\/src\/ckan\/test-core.ini/config:..\/ckan\/test-core.ini/' test.ini
+
+echo "Moving test.ini into a subdir..."
+mkdir subdir
+mv test.ini subdir
 
 echo "travis-install-dependencies is done."

--- a/ckanext/ed/plugin.py
+++ b/ckanext/ed/plugin.py
@@ -34,6 +34,11 @@ class EDPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     # IPackageController
     def before_search(self, search_params):
+        # For requests dashboard we need approval_pending datasets. Passing in
+        # extras that request is sent from dashboard. Return params as is if so
+        if search_params.get('extras', {}).get('from_dashboard'):
+            return search_params
+
         search_params.update({
             'fq': '!(approval_state:approval_pending) ' + search_params.get('fq', '')
         })
@@ -47,7 +52,10 @@ class EDPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     # IRoutes
     def before_map(self, map):
-        publish_controller = 'ckanext.ed.controller:ApproveRejectControler'
+        publish_controller = 'ckanext.ed.controller:ApproveRejectController'
+        map.connect('dashboard.requests', '/dashboard/requests',
+                    controller='ckanext.ed.controller:PendingRequestsController',
+                    action='list_requests')
         map.connect('/dataset-publish/{id}/approve',
                     controller=publish_controller,
                     action='approve')

--- a/ckanext/ed/templates/snippets/package_item.html
+++ b/ckanext/ed/templates/snippets/package_item.html
@@ -7,3 +7,10 @@
     <i class="fa fa-bar-chart-o"></i> {{ ungettext('{total_views} view', '{total_views} views', total_views).format(total_views=total_views) }}
   </div>
 {% endblock %}
+
+{% block heading_meta %}
+  {{ super() }}
+  {% if package.get('approval_state', '') == 'approval_pending' %}
+    <span class="label label-warning">{{ _('Pending') }}</span>
+  {% endif %}
+{% endblock %}

--- a/ckanext/ed/templates/user/dashboard.html
+++ b/ckanext/ed/templates/user/dashboard.html
@@ -1,0 +1,52 @@
+{% extends "user/edit_base.html" %}
+
+{% set user = g.userobj %}
+
+{% block breadcrumb_content %}
+  <li class="active"><a href="{{ h.url_for('dashboard.index') }}">{{ _('Dashboard') }}</a></li>
+{% endblock %}
+
+{% block secondary %}{% endblock %}
+
+{% block primary %}
+  <article class="module">
+    {% block page_header %}
+      <header class="module-content page-header hug">
+        <div class="content_action">
+          {# TODO: Bring this back. Atm errors with  'ckan.lib.app_globals._Globals object' has no attribute 'userobj' #}
+          {# {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %} #}
+        </div>
+        <ul class="nav nav-tabs">
+          {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
+          {% if h.ed_is_admin(c.user) %}
+            {{ h.build_nav_icon('dashboard.requests', _('Requests')) }}
+          {% endif %}
+          {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
+          {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
+          {{ h.build_nav_icon('dashboard.groups', _('My Groups')) }}
+        </ul>
+      </header>
+    {% endblock %}
+    <div class="module-content">
+      {% if self.page_primary_action() | trim %}
+        <div class="page_primary_action">
+          {% block page_primary_action %}{% endblock %}
+        </div>
+      {% endif %}
+      {% block primary_content_inner %}
+        <div data-module="dashboard">
+          {% snippet 'user/snippets/followee_dropdown.html', context=dashboard_activity_stream_context, followees=followee_list %}
+          <h2 class="page-heading">
+            {% block page_heading %}
+              {{ _('News feed') }}
+            {% endblock %}
+            <small>{{ _("Activity from items that I'm following") }}</small>
+          </h2>
+          {% block activity_stream %}
+            {{ dashboard_activity_stream|safe }}
+          {% endblock %}
+        </div>
+      {% endblock %}
+    </div>
+  </article>
+{% endblock %}

--- a/ckanext/ed/templates/user/dashboard.html
+++ b/ckanext/ed/templates/user/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "user/edit_base.html" %}
 
-{% set user = g.userobj %}
+{% set user = c.userobj %}
 
 {% block breadcrumb_content %}
   <li class="active"><a href="{{ h.url_for('dashboard.index') }}">{{ _('Dashboard') }}</a></li>
@@ -13,13 +13,12 @@
     {% block page_header %}
       <header class="module-content page-header hug">
         <div class="content_action">
-          {# TODO: Bring this back. Atm errors with  'ckan.lib.app_globals._Globals object' has no attribute 'userobj' #}
-          {# {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %} #}
+          {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
           {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
           {% if h.ed_is_admin(c.user) %}
-            {{ h.build_nav_icon('dashboard.requests', _('Requests')) }}
+            {{ h.build_nav_icon('dashboard.requests', _('Pending dataset requests')) }}
           {% endif %}
           {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
           {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}

--- a/ckanext/ed/templates/user/dashboard_requests.html
+++ b/ckanext/ed/templates/user/dashboard_requests.html
@@ -1,0 +1,15 @@
+{% extends "user/dashboard.html" %}
+
+{% block dashboard_activity_stream_context %}{% endblock %}
+
+
+{% block primary_content_inner %}
+  <h2 class="hide-heading">{{ _('My Datasets') }}</h2>
+  {% if pending_dataset %}
+    {% snippet 'snippets/package_list.html', packages=pending_dataset %}
+  {% else %}
+    <p class="empty">
+      {{ _('No Pending Requests') }}
+    </p>
+  {% endif %}
+{% endblock %}

--- a/ckanext/ed/tests/test_controllers.py
+++ b/ckanext/ed/tests/test_controllers.py
@@ -1,0 +1,164 @@
+from nose.tools import assert_raises
+
+from ckan.lib.helpers import url_for
+from ckan.plugins import toolkit
+from ckan.tests import helpers, factories
+
+class TestController(helpers.FunctionalTestBase):
+
+    @classmethod
+    def setup_class(cls):
+
+        helpers.reset_db()
+        super(TestController, cls).setup_class()
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestController, cls).teardown_class()
+        helpers.reset_db()
+
+    def setup(self):
+        super(TestController, self).setup()
+        sysadmin = factories.Sysadmin()
+        self.extra_environ = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+
+    def test_requests_403_for_anonimous_users(self):
+        app = self._get_test_app()
+
+        with assert_raises(toolkit.NotAuthorized) as e:
+            app.get(url=url_for('dashboard.requests'), status=403)
+
+
+    def test_requests_tab_not_appears_for_member_on_dashboard(self):
+        app = self._get_test_app()
+        member = factories.User()
+        factories.Organization(users=[{'name': member['name'], 'capacity': 'reader'}])
+
+        extra_environ = {'REMOTE_USER': member['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        assert '<a href="/dashboard/requests">Requests</a>' not in resp
+
+    def test_requests_tab_not_appears_for_editor_on_dashboard(self):
+        app = self._get_test_app()
+        editor = factories.User()
+        factories.Organization(users=[{'name': editor['name'], 'capacity': 'editor'}])
+
+        extra_environ = {'REMOTE_USER': editor['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        assert '<a href="/dashboard/requests">Requests</a>' not in resp
+
+    def test_requests_tab_appears_for_admin_on_dashboard(self):
+        app = self._get_test_app()
+        editor = factories.User()
+        factories.Organization(users=[{'name': editor['name'], 'capacity': 'admin'}])
+
+        extra_environ = {'REMOTE_USER': editor['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        assert '<a href="/dashboard/requests">Requests</a>' in resp
+
+    def test_requests_tab_appears_for_sysadmin_on_dashboard(self):
+        app = self._get_test_app()
+        sysadmin = factories.Sysadmin()
+        factories.Organization(users=[{'name': sysadmin['name'], 'capacity': 'sysadmin'}])
+
+        extra_environ = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        assert '<a href="/dashboard/requests">Requests</a>' in resp
+
+    def test_pending_datasets_show_up_on_dashboard(self):
+        app = self._get_test_app()
+        # Create Users
+        editor = factories.User()
+        admin = factories.User()
+        factories.Organization(
+            users=[
+                {'name': admin['name'], 'capacity': 'admin'},
+                {'name': editor['name'], 'capacity': 'editor'}
+            ],
+            name='us-ed-1',
+            id='us-ed-1'
+        )
+        # Create Datasets
+        context = {'user': editor['name']}
+        data_dict = _create_dataset_dict('test-pending-1', 'us-ed-1')
+        helpers.call_action('package_create', context, **data_dict)
+
+        extra_environ = {'REMOTE_USER': admin['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        assert 'TEST-PENDING-1' in resp, resp
+
+    def test_non_pending_datasets_do_not_show_up_on_dashboard(self):
+        app = self._get_test_app()
+        # Create Users
+        editor = factories.User()
+        admin = factories.User()
+        factories.Organization(
+            users=[
+                {'name': admin['name'], 'capacity': 'admin'},
+                {'name': editor['name'], 'capacity': 'editor'}
+            ],
+            name='us-ed-1',
+            id='us-ed-1'
+        )
+        # Create Datasets
+        context = {'user': admin['name']}
+        data_dict_1 = _create_dataset_dict('test-pending-1', 'us-ed-1')
+        helpers.call_action('package_create', context, **data_dict_1)
+        context = {'user': editor['name']}
+        data_dict_2 = _create_dataset_dict('test-pending-2', 'us-ed-1')
+        helpers.call_action('package_create', context, **data_dict_2)
+
+        extra_environ = {'REMOTE_USER': admin['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        # By admin should not be there
+        assert 'TEST-PENDING-1' not in resp
+        # By editor should be there
+        assert 'TEST-PENDING-2' in resp
+
+    def test_pending_datasets_from_other_office_dont_show_up_for_admin(self):
+        app = self._get_test_app()
+        # Create Users
+        editor_native = factories.User()
+        editor_forigner = factories.User()
+        admin = factories.User()
+        factories.Organization(
+            users=[
+                {'name': admin['name'], 'capacity': 'admin'},
+                {'name': editor_native['name'], 'capacity': 'editor'}
+            ],
+            name='us-ed-1',
+            id='us-ed-1'
+        )
+        factories.Organization(
+            users=[{'name': editor_forigner['name'], 'capacity': 'editor'}],
+            name='us-ed-2',
+            id='us-ed-2'
+        )
+        # Create Datasets
+        context = {'user': editor_native['name']}
+        data_dict_native = _create_dataset_dict('test-pending-native', 'us-ed-1')
+        helpers.call_action('package_create', context, **data_dict_native)
+
+        context = {'user': editor_forigner['name']}
+        data_dict_forign = _create_dataset_dict('test-pending-forign', 'us-ed-2')
+        helpers.call_action('package_create', context, **data_dict_forign)
+
+        extra_environ = {'REMOTE_USER': admin['name'].encode('ascii')}
+        resp = app.get(url=url_for('dashboard.requests'), extra_environ=extra_environ)
+        assert 'TEST-PENDING-FORIGN' not in resp
+        assert 'TEST-PENDING-NATIVE' in resp
+
+
+def _create_dataset_dict(package_name, office_name='us-ed'):
+    return {
+        'name': package_name,
+        'contact_name': 'Stu Shepard',
+        'program_code': '321',
+        'access_level': 'public',
+        'bureau_code': '123',
+        'contact_email': '%s@email.com' % package_name,
+        'notes': 'notes',
+        'owner_org': office_name,
+        'title': package_name.upper(),
+        'identifier': 'identifier'
+    }

--- a/test.ini
+++ b/test.ini
@@ -11,7 +11,7 @@ port = 5000
 [app:main]
 use = config:../../src/ckan/test-core.ini
 
-ckan.plugins = scheming_datasets ed
+ckan.plugins = scheming_datasets ed showcase
 scheming.dataset_schemas=ckanext.ed.schemas:dataset.json
 scheming.presets=ckanext.scheming:presets.json ckanext.ed.schemas:presets.json
 


### PR DESCRIPTION
- endpoint, controller and template for dashboard
- proper logic for package_search and before_search to filter datasts by the pending flag
- tests

Note: PR is ready to review except this one line that is erroring and I commented out for now. I need to bring it back but could not figure out why that is happening https://github.com/CivicActions/ckanext-ed/commit/129d1ea9a5b6c00d34cfb706d7a365bd984e9ecc#diff-5bc524325f18511397186ec87f691d6eR17

![image](https://user-images.githubusercontent.com/15143785/49685670-e2e48900-fb00-11e8-83e0-2a0dc8398d09.png)
