### PR TITLE
Fixes for Demo 24-May

### DIFF
--- a/ckanext/ed/templates/home/layout1.html
+++ b/ckanext/ed/templates/home/layout1.html
@@ -56,7 +56,7 @@
                   </div>
                   <div class="col-links-2">
                     <ul>
-                      {% for category in c.search_facets.groups['items'][9:] %}
+                      {% for category in c.search_facets.groups['items'][9:18] %}
                         <li>
                             {% set href = "/dataset?groups=" + category.name %}
                             <a href="{{ href }}">{{ h.truncate(category['display_name'], 22) }}<span>{{ category.count }}</span></a>

--- a/ckanext/ed/templates/package/disqus.html
+++ b/ckanext/ed/templates/package/disqus.html
@@ -13,14 +13,14 @@
     <div class="inner-sidebar">
       <section class="module module-narrow module-shallow">
           <h4 class="side-heading"> Helpdesk </h4>
-          <a href="#" class="underline">crdc-help@ed.gov</a>
-          <a href="#">123-456-7891</a>
+          <a href="#" class="underline">{{ pkg.helpdesk_email }}</a>
+          <a href="#">{{ pkg.helpdesk_phone }}</a>
       </section>
 
       <section class="module module-narrow module-shallow">
           <h4 class="side-heading"> Data steward </h4>
-          <a href="#">Jane Doe</a>
-          <a href="#" class="underline">jane.doe@ed.gov</a>
+          <a href="#">{{ pkg.contact_name }}</a>
+          <a href="#" class="underline">{{ pkg.contact_email }}</a>
       </section>
     </div>
 

--- a/ckanext/ed/templates/package/read_base.html
+++ b/ckanext/ed/templates/package/read_base.html
@@ -24,12 +24,12 @@
   <div class="row main-info">
     <div class="col-custom">
       <label>Updated</label>
-      <span>March 1, 2019</span>
+      <span>{{ pkg.metadata_modified }}</span>
     </div>
 
     <div class="col-md-2">
       <label>License</label>
-      <span>Creative Commons Attribution</span>
+      <span>{{ pkg.license_title }}</span>
     </div>
 
     {% block package_organization %}
@@ -43,10 +43,10 @@
 
 
     <div class="col-md-3">
-      <label>Tags</label>
-      <a href="#" class="tag-custom">#entrollment</a>
-      <a href="#" class="tag-custom">#equity</a>
-      <a href="#" class="tag-custom">#civil-rights</a>
+    {% for tag in pkg.tags %}
+        {% set href = "/dataset?tags=" + tag['name'] %}
+      <a href="{{href}}" class="tag-custom">#{{tag.name}}</a>
+    {% endfor %}
     </div>
   </div>
 


### PR DESCRIPTION
- Display only 18 items on rightmost col of categories homepage.
- Connected to backend:
  - Last updated.
  - License.
  - Tags.
  - Helpdesk email & phone.
  - Data Steward contact details