### PR TITLE
load resources directly on dataset page - fixes #163

### DIFF
--- a/ckanext/ed/controller.py
+++ b/ckanext/ed/controller.py
@@ -131,7 +131,7 @@ class EdPackageController(PackageController):
     def _resource_read(self, package, resource_id, context={}):
         '''Same as resource_read() from PackageController https://github.com/ckan/ckan/blob/f43d6a572838c792193f3239827d04f9ffea9206/ckan/controllers/package.py#L1083
 
-        Does exactly the same except this returns data instead of rendering 
+        Does exactly the same except this returns data instead of rendering
         '''
         c.package = package
 
@@ -201,7 +201,7 @@ class DocumentationController(PackageController):
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
             c.pkg = context['package']
-        except (NotFound, NotAuthorized):
+        except (NotFound, NotAuthorized, toolkit.NotAuthorized):
             abort(404, _('Dataset not found'))
 
         package_type = c.pkg_dict['type'] or 'dataset'

--- a/ckanext/ed/controller.py
+++ b/ckanext/ed/controller.py
@@ -2,7 +2,6 @@ import os
 import logging
 import cgi
 
-
 from ckan.common import g, _, response, request, c, config
 import ckan.lib.helpers as h
 from paste.deploy.converters import asbool
@@ -46,9 +45,6 @@ UsernamePasswordError = logic.UsernamePasswordError
 DataError = dictization_functions.DataError
 unflatten = dictization_functions.unflatten
 
-
-
-
 abort = base.abort
 
 get_action = logic.get_action
@@ -58,6 +54,134 @@ clean_dict = logic.clean_dict
 tuplize_dict = logic.tuplize_dict
 parse_params = logic.parse_params
 
+
+class EdPackageController(PackageController):
+    def read(self, id):
+        '''Overrifing base packe read controller. https://github.com/ckan/ckan/blob/f43d6a572838c792193f3239827d04f9ffea9206/ckan/controllers/package.py#L360
+
+        Does exectly the same exapt it also includes info about resource selected.
+        '''
+        context = {'model': model, 'session': model.Session,
+                   'user': c.user, 'for_view': True,
+                   'auth_user_obj': c.userobj}
+        data_dict = {'id': id, 'include_tracking': True}
+
+        # interpret @<revision_id> or @<date> suffix
+        split = id.split('@')
+        if len(split) == 2:
+            data_dict['id'], revision_ref = split
+            if model.is_id(revision_ref):
+                context['revision_id'] = revision_ref
+            else:
+                try:
+                    date = h.date_str_to_datetime(revision_ref)
+                    context['revision_date'] = date
+                except TypeError as e:
+                    abort(400, _('Invalid revision format: %r') % e.args)
+                except ValueError as e:
+                    abort(400, _('Invalid revision format: %r') % e.args)
+        elif len(split) > 2:
+            abort(400, _('Invalid revision format: %r') %
+                  'Too many "@" symbols')
+
+        # check if package exists
+        try:
+            c.pkg_dict = get_action('package_show')(context, data_dict)
+            c.pkg = context['package']
+        except (NotFound, NotAuthorized, toolkit.NotAuthorized):
+            base.abort(404, _('Dataset not found'))
+
+        resource_id = request.params.get('resource')
+        for resource in c.pkg_dict['resources']:
+            resource_views = get_action('resource_view_list')(
+                context, {'id': resource['id']})
+            resource['has_views'] = len(resource_views) > 0
+            # Backwards compatibility with preview interface
+            resource['can_be_previewed'] = bool(len(resource_views))
+
+            if not resource_id and resource.get('resource_type') != 'doc':
+                resource_id = resource['id']
+
+        package_type = c.pkg_dict['type'] or 'dataset'
+        self._setup_template_variables(context, {'id': id},
+                                       package_type=package_type)
+
+        template = self._read_template(package_type)
+
+
+        vars = {'dataset_type': package_type}
+        if resource_id:
+            vars = self._resource_read(c.pkg_dict, resource_id, context=context)
+        c.current_package_id = c.pkg.id
+        c.current_resource_id = resource_id
+        try:
+            return render(template, extra_vars=vars)
+        except ckan.lib.render.TemplateNotFound as e:
+            msg = _(
+                "Viewing datasets of type \"{package_type}\" is "
+                "not supported ({file_!r}).".format(
+                    package_type=package_type,
+                    file_=e.message
+                )
+            )
+            abort(404, msg)
+
+        assert False, "We should never get here"
+
+    def _resource_read(self, package, resource_id, context={}):
+        '''Same as resource_read() from PackageController https://github.com/ckan/ckan/blob/f43d6a572838c792193f3239827d04f9ffea9206/ckan/controllers/package.py#L1083
+
+        Does exactly the same except this returns data instead of rendering 
+        '''
+        c.package = package
+
+        for resource in c.package.get('resources', []):
+            if resource['id'] == resource_id:
+                c.resource = resource
+                break
+        if not c.resource:
+            abort(404, _('Resource not found'))
+
+        dataset_type = c.pkg.type or 'dataset'
+
+        # get package license info
+        license_id = c.package.get('license_id')
+        try:
+            c.package['isopen'] = model.Package.\
+                get_license_register()[license_id].isopen()
+        except KeyError:
+            c.package['isopen'] = False
+
+        # Deprecated: c.datastore_api - use h.action_url instead
+        c.datastore_api = '%s/api/action' % \
+            config.get('ckan.site_url', '').rstrip('/')
+
+        resource_views = get_action('resource_view_list')(
+            context, {'id': resource_id})
+        c.resource['has_views'] = len(resource_views) > 0
+
+        c.resource['can_be_previewed'] = bool(len(resource_views))
+
+        current_resource_view = None
+        view_id = request.GET.get('view_id')
+        if c.resource['has_views']:
+            if view_id:
+                current_resource_view = [rv for rv in resource_views
+                                         if rv['id'] == view_id]
+                if len(current_resource_view) == 1:
+                    current_resource_view = current_resource_view[0]
+                else:
+                    abort(404, _('Resource view not found'))
+            else:
+                current_resource_view = resource_views[0]
+        elif c.resource['can_be_previewed'] and not view_id:
+            current_resource_view = None
+
+        vars = {'resource_views': resource_views,
+                'current_resource_view': current_resource_view,
+                'dataset_type': dataset_type,
+                'resource_id': resource_id}
+        return vars
 
 class DocumentationController(PackageController):
     def read_doc(self, id):

--- a/ckanext/ed/plugin.py
+++ b/ckanext/ed/plugin.py
@@ -126,6 +126,13 @@ class EDPlugin(plugins.SingletonPlugin, DefaultTranslation):
                     controller='ckanext.ed.controller:DisqusController',
                     action='read_disqus')
 
+        ## package
+        map.connect('dataset.new','/dataset/new',
+                    controller='ckan.controllers.package:PackageController',
+                    action='new')
+        map.connect('/dataset/{id}',
+                    controller='ckanext.ed.controller:EdPackageController',
+                    action='read')
         return map
 
     # IValidators

--- a/ckanext/ed/templates/package/documentations.html
+++ b/ckanext/ed/templates/package/documentations.html
@@ -9,13 +9,6 @@
 {% set has_reorder = c.pkg_dict and c.pkg_dict.resources and c.pkg_dict.resources|length > 0 %}
 {% set docs_here = {} %}
 
-{% block page_primary_action %}
-  {% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
-    {% link_for _('Add new doc'), controller='ckanext.ed.controller:NewResourceController', action='new_doc', id=c.pkg_dict.name, class_='btn btn-primary', icon='plus' %}
-    {% set has_reorder = False %}
-  {% endif %}
-{% endblock %}
-
 {% block primary_content_inner %}
 
     <!-- Sidebar Section -->
@@ -24,19 +17,30 @@
 
       <nav id="spy">
           <ul class="sidebar-nav nav">
-              <li class="sidebar-brand">
-                  <a href="#anch0">Link 1 to file</a>
-              </li>
-              <li class="sidebar-brand">
-                  <a href="#anch0">Project Documentation</a>
-              </li>
-              
+            <li class="sidebar-brand">
+              <a href="#about">About</a>
+            </li>
+            {% if pkg.resources %}
+              {% for resource in c.pkg_dict['resources']%}
+                {% if resource.resource_type == 'doc' %}
+                  <li class="sidebar-brand">
+                      {% if resource.pinned == 'True'%}
+                        <a href="#pinned"><b>Pinned</b></a>
+                        <a href="#about">About</a>
+                      {% else %}
+                        <a href="#{{resource.id}}">{{resource.name}}</a>
+                      {% endif %}
+                  </li>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
           </ul>
       </nav>
     </div>
 
     <!-- Primary Section -->
     <div class="inner-primary">
+      <h4>Documentation</h4>
       {% if pkg.resources %}
         <ul class="resource-list"{% if has_reorder %} data-module="resource-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
           {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
@@ -44,7 +48,7 @@
             {% if resource.resource_type == 'doc' %}
               <!-- Ugly workarund to update docs_here -->
               {% if docs_here.update({'here': True }) %} {% endif %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=edit, can_edit=can_edit %}
+              {% snippet 'package/snippets/doc_item.html', pkg=pkg, res=resource, url_is_edit=edit, can_edit=can_edit, res_num=loop.index %}
             {% endif %}
           {% endfor %}
         </ul>

--- a/ckanext/ed/templates/package/documentations.html
+++ b/ckanext/ed/templates/package/documentations.html
@@ -9,63 +9,79 @@
 {% set has_reorder = c.pkg_dict and c.pkg_dict.resources and c.pkg_dict.resources|length > 0 %}
 {% set docs_here = {} %}
 
+{% block page_primary_action %}
+  {% if edit %}
+    {% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
+      {% link_for _('Add new doc '), controller='ckanext.ed.controller:NewResourceController', action='new_doc', id=c.pkg_dict.name, class_='btn btn-primary', icon='plus' %}
+      {% set has_reorder = True %}
+    {% endif %}
+  {% else %}
+  {% endif %}
+{% endblock %}
+
 {% block primary_content_inner %}
+{% if not edit %}
+  <!-- Sidebar Section -->
+  <div class="inner-sidebar">
+    <h4 class="side-heading">Documentation</h4>
 
-    <!-- Sidebar Section -->
-    <div class="inner-sidebar">
-      <h4 class="side-heading">Documentation</h4>
-
-      <nav id="spy">
-          <ul class="sidebar-nav nav">
-            <li class="sidebar-brand">
-              <a href="#about">About</a>
-            </li>
-            {% if pkg.resources %}
-              {% for resource in c.pkg_dict['resources']%}
-                {% if resource.resource_type == 'doc' %}
-                  <li class="sidebar-brand">
-                      {% if resource.pinned == 'True'%}
-                        <a href="#pinned"><b>Pinned</b></a>
-                        <a href="#about">About</a>
-                      {% else %}
-                        <a href="#{{resource.id}}">{{resource.name}}</a>
-                      {% endif %}
-                  </li>
-                {% endif %}
-              {% endfor %}
-            {% endif %}
-          </ul>
-      </nav>
-    </div>
-
-    <!-- Primary Section -->
-    <div class="inner-primary">
-      <h4>Documentation</h4>
-      {% if pkg.resources %}
-        <ul class="resource-list"{% if has_reorder %} data-module="resource-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
-          {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
-          {% for resource in pkg.resources %}
-            {% if resource.resource_type == 'doc' %}
-              <!-- Ugly workarund to update docs_here -->
-              {% if docs_here.update({'here': True }) %} {% endif %}
-              {% snippet 'package/snippets/doc_item.html', pkg=pkg, res=resource, url_is_edit=edit, can_edit=can_edit, res_num=loop.index %}
-            {% endif %}
-          {% endfor %}
+    <nav id="spy">
+        <ul class="sidebar-nav nav">
+          <li class="sidebar-brand">
+            <a href="#about">About</a>
+          </li>
+          {% if pkg.resources %}
+            {% for resource in c.pkg_dict['resources']%}
+              {% if resource.resource_type == 'doc' %}
+                <li class="sidebar-brand">
+                    {% if resource.pinned == 'True'%}
+                      <a href="#pinned"><b>Pinned</b></a>
+                      <a href="#about">About</a>
+                    {% else %}
+                      <a href="#{{resource.id}}">{{resource.name}}</a>
+                    {% endif %}
+                </li>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
         </ul>
-      {% endif %}
-      {% if not docs_here.here %}
-        {% trans url=h.url_for(controller='ckanext.ed.controller:NewResourceController', action='new_doc', id=pkg.name) %}
-          <p class="empty">This dataset has no documentation, <a href="{{ url }}">why not add one?</a></p>
-        {% endtrans %}
-      {% endif %}
-      {% endblock %}
+    </nav>
+  </div>
+<!-- Primary Section -->
+{% endif %}
+<div class="inner-primary">
+  {% if not edit %}
+    <h4>Documentation</h4>
+  {% endif %}
+  {% if pkg.resources %}
+    <ul class="resource-list"{% if has_reorder %} data-module="resource-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
+      {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+      {% for resource in pkg.resources %}
+        {% if resource.resource_type == 'doc' %}
+          <!-- Ugly workarund to update docs_here -->
+          {% if docs_here.update({'here': True }) %} {% endif %}
+          {% if edit %}
+            {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=edit, can_edit=can_edit %}
+          {% else %}
+            {% snippet 'package/snippets/doc_item.html', pkg=pkg, res=resource, url_is_edit=edit, can_edit=can_edit, res_num=loop.index %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    </ul>
+  {% endif %}
+  {% if not docs_here.here %}
+    {% trans url=h.url_for(controller='ckanext.ed.controller:NewResourceController', action='new_doc', id=pkg.name) %}
+      <p class="empty">This dataset has no documentation, <a href="{{ url }}">why not add one?</a></p>
+    {% endtrans %}
+  {% endif %}
+  {% endblock %}
 
-      {% block scripts %}
-      {{ super() }}
-      {% if has_reorder %}
-        {% resource 'vendor/reorder' %}
-      {% endif %}
-      {% endblock %}
-    </div>
+  {% block scripts %}
+  {{ super() }}
+  {% if has_reorder %}
+    {% resource 'vendor/reorder' %}
+  {% endif %}
+  {% endblock %}
+</div>
 
-    <p class="clearfix"></p>
+<p class="clearfix"></p>

--- a/ckanext/ed/templates/package/new_resource_not_draft.html
+++ b/ckanext/ed/templates/package/new_resource_not_draft.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block form %}
+  {% snippet resource_form_snippet, data=data, errors=errors, error_summary=error_summary, include_metadata=false, pkg_name=pkg_name, stage=stage, dataset_type=dataset_type, is_doc=is_doc %}
+{% endblock %}

--- a/ckanext/ed/templates/package/read.html
+++ b/ckanext/ed/templates/package/read.html
@@ -10,33 +10,58 @@
   <!-- Sidebar Section -->
   <div class="inner-sidebar">
     <section class="content-pad">
-        
-        <a href="#">
-          <div class="dataset-card active">
-              <span class="format">CSV</span>
-              <h5>2018-19 CRDC LEA DATA</h5>
-
-              <button class="usa-button download-btn">Download </button>
-              <button class="usa-button download-btn outline">API</button>
-
-              <i class="material-icons">done</i>
-          </div>
-        </a>
-
-        <a href="#">
-        <div class="dataset-card">
-            <span class="format">CSV</span>
-            <h5>2018-19 CRDC LEA DATA</h5>
-        </div>
-        </a>
-
-        <a href="#">
-          <div class="dataset-card">
-            <span class="format">CSV</span>
-            <h5>2018-19 CRDC LEA DATA</h5>
-          </div>
-        </a>
-
+        {% for resource in pkg.resources %}
+          {% if resource.resource_type != 'doc' %}
+          {% set active = '' %}
+          {% if resource.id == c.current_resource_id %}
+            {% set active = 'active' %}
+          {% endif %}
+            <a href=/dataset/{{pkg.name}}?resource={{resource.id}}>
+            <div class="dataset-card {{active}}">
+                <span class="format">{{resource.format}}</span>
+                {% if resource.url and h.is_url(resource.url) %}
+                  <h5>{{resource.name | upper }}</h5>
+                  {% if active %}
+                    <a class="usa-button download-btn resource-type-{{ resource.resource_type }}" href="{{ resource.url }}">
+                      {% if resource.resource_type in ('listing', 'service') %}
+                        <i class="fa fa-eye"></i> {{ _('View') }}
+                      {% elif  resource.resource_type == 'api' %}
+                        <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+                      {% elif (not resource.has_views or not resource.can_be_previewed) and not resource.url_type == 'upload' %}
+                        <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+                      {% else %}
+                        {{ _('Download') }}
+                      {% endif %}
+                    </a>
+                    {%if resource.datastore_active %}
+                      <button class="usa-button download-btns dropdown-toggle" data-toggle="dropdown">
+                       <span class="caret"></span>
+                      </button>
+                      <ul class="dropdown-menu">
+                        <li>
+                          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=resource.id, bom=True) }}"
+                           target="_blank"><span>CSV</span></a>
+                          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=resource.id, format='tsv', bom=True) }}"
+                           target="_blank"><span>TSV</span></a>
+                          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=resource.id, format='json') }}"
+                           target="_blank"><span>JSON</span></a>
+                          <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=resource.id, format='xml') }}"
+                           target="_blank"><span>XML</span></a>
+                        </li>
+                      </ul>
+                    {%endif%}
+                    {% set loading_text = _('Loading...') %}
+                    {% if resource.datastore_active %}
+                    {% set api_info_url = h.url_for(controller='api', action='snippet', ver=1, snippet_path='api_info.html', resource_id=resource.id) %}
+                      <a class="usa-button download-btn outline btn btn-success" href="{{ api_info_url }}" data-module="api-info" data-module-template="{{ api_info_url }}" data-loading-text="{{ loading_text }}"><i class="fa fa-flask fa-lg"></i> {{ _('API') }}</a>
+                    {% endif %}
+                    <i class="material-icons">done</i>
+                  {% endif %}
+                {% endif %}
+            </div>
+            </a>
+            {% endif %}
+        {% endfor %}
     </section>
   </div>
 
@@ -72,19 +97,17 @@
       <span class="insert-comment-thread"></span>
     {% endblock %}
     {% block package_resources %}
-      {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources, is_doc=is_doc %}
-    {% endblock %}
-
-    {% block package_tags %}
-      {% snippet "package/snippets/tags.html", tags=pkg.tags %}
-    {% endblock %}
-
-    {% block package_additional_info %}
-      {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
+      {% if c.resources %}
+      {% snippet "package/snippets/resource_read.html",
+        pkg=pkg,
+        current_resource_view=current_resource_view,
+        resource_views=resource_views
+      %}
+      {% endif %}
     {% endblock %}
   </div>
 
   <p class="clearfix"></p>
-  
+
 
 {% endblock %}

--- a/ckanext/ed/templates/package/read.html
+++ b/ckanext/ed/templates/package/read.html
@@ -77,7 +77,6 @@
       {% endif %}
       <h1>
         {% block page_heading %}
-          {{ h.dataset_display_name(pkg) }}
           {% if pkg.state.startswith('draft') %}
             [{{ _('Draft') }}]
           {% endif %}
@@ -86,15 +85,6 @@
           {% endif %}
         {% endblock %}
       </h1>
-      {% block package_notes %}
-        {% if pkg.notes %}
-          <div class="notes embedded-content">
-            {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
-          </div>
-        {% endif %}
-      {% endblock %}
-      {# FIXME why is this here? seems wrong #}
-      <span class="insert-comment-thread"></span>
     {% endblock %}
     {% block package_resources %}
       {% if c.resource %}

--- a/ckanext/ed/templates/package/read.html
+++ b/ckanext/ed/templates/package/read.html
@@ -97,7 +97,7 @@
       <span class="insert-comment-thread"></span>
     {% endblock %}
     {% block package_resources %}
-      {% if c.resources %}
+      {% if c.resource %}
       {% snippet "package/snippets/resource_read.html",
         pkg=pkg,
         current_resource_view=current_resource_view,

--- a/ckanext/ed/templates/package/snippets/doc_item.html
+++ b/ckanext/ed/templates/package/snippets/doc_item.html
@@ -5,21 +5,15 @@
 {% if res.pinned == 'True' or res_num==1 %}
   {% if res.pinned == 'True'%}
     <h5 id="pinned">Pinned</h5>
-    {% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
-      {% link_for _('Unpin'), controller='ckanext.ed.controller:DocumentationController', action='unpin', dataset_id=c.pkg_dict.name, resource_id=res.id, class_='btn btn-primary', icon='map-marker'%}
-    {% endif %}
     <br>
     What we think you probably want to look at first.
   {% else %}
     <h5 id="{{res.id}}">{{h.resource_display_name(res) | truncate(50)}}</h5>
-    {% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
-      {% link_for _('Pin'), controller='ckanext.ed.controller:DocumentationController', action='pin', dataset_id=c.pkg_dict.name, resource_id=res.id, class_='btn btn-primary', icon='map-marker'%}
-    {% endif %}
   {% endif %}
   <br>
   <ul>
     {% if res.url %}
-    <li><a href={{res.url}}>PDF</a></li>
+    <li><a href={{res.url}}>{{res.format|upper}}</a></li>
     {% endif %}
     {% if res.external_website %}
     <li><a href={{res.external_website}}>External Website</a></li>
@@ -44,12 +38,9 @@
   </table>
 {% else %}
 <h5 id="{{res.id}}">{{h.resource_display_name(res) | truncate(50)}}</h5>
-{% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
-  {% link_for _('Pin'), controller='ckanext.ed.controller:DocumentationController', action='pin', dataset_id=c.pkg_dict.name, resource_id=res.id, class_='btn btn-primary', icon='map-marker'%}
-{% endif %}
 <ul>
   {% if res.url %}
-  <li><a href={{res.url}}>PDF</a></li>
+  <li><a href={{res.url}}>{{res.format|upper}}</a></li>
   {% endif %}
   {% if res.external_website %}
   <li><a href={{res.external_website}}>External Website</a></li>

--- a/ckanext/ed/templates/package/snippets/doc_item.html
+++ b/ckanext/ed/templates/package/snippets/doc_item.html
@@ -1,0 +1,58 @@
+{% set url_action = 'resource_edit' if url_is_edit and can_edit else 'resource_read' %}
+{% set url = h.url_for(controller='package', action=url_action, id=pkg.name, resource_id=res.id) %}
+
+
+{% if res.pinned == 'True' or res_num==1 %}
+  {% if res.pinned == 'True'%}
+    <h5 id="pinned">Pinned</h5>
+    {% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
+      {% link_for _('Unpin'), controller='ckanext.ed.controller:DocumentationController', action='unpin', dataset_id=c.pkg_dict.name, resource_id=res.id, class_='btn btn-primary', icon='map-marker'%}
+    {% endif %}
+    <br>
+    What we think you probably want to look at first.
+  {% else %}
+    <h5 id="{{res.id}}">{{h.resource_display_name(res) | truncate(50)}}</h5>
+    {% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
+      {% link_for _('Pin'), controller='ckanext.ed.controller:DocumentationController', action='pin', dataset_id=c.pkg_dict.name, resource_id=res.id, class_='btn btn-primary', icon='map-marker'%}
+    {% endif %}
+  {% endif %}
+  <br>
+  <ul>
+    {% if res.url %}
+    <li><a href={{res.url}}>PDF</a></li>
+    {% endif %}
+    {% if res.external_website %}
+    <li><a href={{res.external_website}}>External Website</a></li>
+    {% endif %}
+  </ul>
+  <br>
+  <h5 id="about">About</h5>
+  <br>
+  {{res.description}}
+  <table class="table table-condensed">
+    <thead>
+      <tr>
+        <th scope="col">{{ _('Metadata') }}</th>
+        <th scope="col">{{ _('Description') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for key, value in h.format_resource_items(res.items()) %}
+        <tr><th scope="row">{{ key }}</th><td>{{ value }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+<h5 id="{{res.id}}">{{h.resource_display_name(res) | truncate(50)}}</h5>
+{% if h.check_access('package_update', {'id': c.pkg_dict.id ,'user': c.user}) %}
+  {% link_for _('Pin'), controller='ckanext.ed.controller:DocumentationController', action='pin', dataset_id=c.pkg_dict.name, resource_id=res.id, class_='btn btn-primary', icon='map-marker'%}
+{% endif %}
+<ul>
+  {% if res.url %}
+  <li><a href={{res.url}}>PDF</a></li>
+  {% endif %}
+  {% if res.external_website %}
+  <li><a href={{res.external_website}}>External Website</a></li>
+  {% endif %}
+</ul>
+{% endif %}

--- a/ckanext/ed/templates/package/snippets/resource_form.html
+++ b/ckanext/ed/templates/package/snippets/resource_form.html
@@ -91,9 +91,9 @@
     {% else %}
       {% block add_button %}
         {% if is_doc %}
-          <button class="btn btn-primary" name="save" value="go-dataset-complete" type="submit">{{ _('Add') }}</button>
-        {% else %}
           <button class="btn btn-primary" name="save" value="go-dataset-complete-from-doc" type="submit">{{ _('Add') }}</button>
+        {% else %}
+          <button class="btn btn-primary" name="save" value="go-dataset-complete" type="submit">{{ _('Add') }}</button>
         {% endif %}
       {% endblock %}
     {% endif %}

--- a/ckanext/ed/templates/package/snippets/resource_read.html
+++ b/ckanext/ed/templates/package/snippets/resource_read.html
@@ -1,0 +1,117 @@
+{% set res = c.resource %}
+
+{% block pre_primary %}
+  {% block resource %}
+    <section class="module module-resource">
+      {% block resource_inner %}
+      <div class="module-content">
+      {% block data_preview %}
+      {% block resource_view %}
+        {% block resource_view_nav %}
+          {% set resource_preview = h.resource_preview(c.resource, c.package) %}
+          {% snippet "package/snippets/resource_views_list.html",
+             views=resource_views,
+             pkg=pkg,
+             is_edit=false,
+             view_id=current_resource_view['id'],
+             resource_preview=resource_preview,
+             resource=c.resource,
+             extra_class="nav-tabs nav-tabs-plain"
+           %}
+        {% endblock %}
+          {% block resource_view_content %}
+            <div class="resource-view">
+              {% set resource_preview = h.resource_preview(c.resource, c.package) %}
+              {% set views_created = res.has_views or resource_preview %}
+              {% if views_created %}
+                {% if resource_preview and not current_resource_view %}
+                  {{ h.resource_preview(c.resource, c.package) }}
+                {% else %}
+                  {% for resource_view in resource_views %}
+                    {% if resource_view == current_resource_view %}
+                      {% snippet 'package/snippets/resource_view.html',
+                         resource_view=resource_view,
+                         resource=c.resource,
+                         package=c.package
+                       %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+              {% else %}
+                {# Views not created #}
+                <div class="data-viewer-info">
+                  <p>{{ _("There are no views created for this resource yet.") }}</p>
+                  {% if h.check_access('resource_view_create', {'resource_id': c.resource.id}) %}
+                    <p class="text-muted">
+                      <i class="fa fa-info-circle"></i>
+                      {{ _("Not seeing the views you were expecting?")}}
+                      <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
+                        {{ _('Click here for more information.') }}</a>
+                    </p>
+                    <div id="data-view-info" class="collapse">
+                      <p>{{ _('Here are some reasons you may not be seeing expected views:') }}</p>
+                      <ul>
+                        <li>{{ _("No view has been created that is suitable for this resource")}}</li>
+                        <li>{{ _("The site administrators may not have enabled the relevant view plugins")}}</li>
+                        <li>{{ _("If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet")}}</li>
+                      </ul>
+                    </div>
+                  {% endif %}
+                </div>
+              {% endif %}
+            </div>
+          {% endblock %}
+        </div>
+      {% endblock %}
+      {% endblock %}
+      {% endblock %}
+    </section>
+  {% endblock %}
+{% endblock %}
+
+{% block primary_content %}
+  {% block resource_additional_information %}
+    {% if res %}
+      <section class="module">
+        {% block resource_additional_information_inner %}
+        <div class="module-content">
+          <h2>{{ _('Additional Information') }}</h2>
+          <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Field') }}</th>
+                <th scope="col">{{ _('Value') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Data last updated') }}</th>
+                <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.created) or _('unknown') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Metadata last updated') }}</th>
+                <td>{{ h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Created') }}</th>
+                <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Format') }}</th>
+                <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('License') }}</th>
+                <td>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
+              </tr>
+              {% for key, value in h.format_resource_items(res.items()) %}
+                <tr class="toggle-more"><th scope="row">{{ key }}</th><td>{{ value }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% endblock %}
+      </section>
+    {% endif %}
+  {% endblock %}
+{% endblock %}

--- a/ckanext/ed/tests/test_controllers.py
+++ b/ckanext/ed/tests/test_controllers.py
@@ -181,12 +181,12 @@ class TestDocumentationController(helpers.FunctionalTestBase):
     def test_documentation_tab_has_pin_button(self):
         app = self._get_test_app()
         resp = app.get(url=url_for('/dataset/docs/%s' % self.pkg), extra_environ=self.envs)
-        assert 'Pin' in resp
+        assert ' Pin' in resp
 
     def test_documentation_tab_has_no_pin_button_for_anonymous(self):
         app = self._get_test_app()
         resp = app.get(url=url_for('/dataset/docs/%s' % self.pkg))
-        assert 'Pin' not in resp
+        assert ' Pin' not in resp
 
     def test_documentation_tab_has_unpin_button(self):
         app = self._get_test_app()

--- a/ckanext/ed/tests/test_controllers.py
+++ b/ckanext/ed/tests/test_controllers.py
@@ -29,6 +29,16 @@ class TestBasicControllers(helpers.FunctionalTestBase):
         factories.Organization(name=self.orgname, id=self.orgname)
         context = _create_context(self.sysadmin)
         data_dict = _create_dataset_dict(self.pkg, self.orgname, private=False)
+        data_dict.update(resources=[
+            {
+                'id': 'data-without-table',
+                'name': 'data-without-table',
+                'url': '',
+                'description': 'resouce',
+                'format': 'csv',
+                'resource_type': 'regular-resource'
+            }
+        ])
         self.package = helpers.call_action('package_create', context, **data_dict)
         self.envs = {'REMOTE_USER': self.sysadmin['name'].encode('ascii')}
         self.app = self._get_test_app()
@@ -60,10 +70,12 @@ class TestBasicControllers(helpers.FunctionalTestBase):
     def test_pakage_page_is_ok_for_anonimous(self):
         resp = self.app.get(url=url_for('/dataset/%s' % self.pkg))
         assert resp.status_int == 200
+        assert 'Additional Information' in resp
 
     def test_pakage_page_is_ok_for_sysadmin(self):
         resp = self.app.get(url=url_for('/dataset/%s' % self.pkg), extra_environ=self.envs)
         assert resp.status_int == 200
+        assert 'Additional Information' in resp
 
 
 class TestNewResourceController(helpers.FunctionalTestBase):

--- a/ckanext/ed/tests/test_controllers.py
+++ b/ckanext/ed/tests/test_controllers.py
@@ -65,6 +65,7 @@ class TestBasicControllers(helpers.FunctionalTestBase):
         resp = self.app.get(url=url_for('/dataset/%s' % self.pkg), extra_environ=self.envs)
         assert resp.status_int == 200
 
+
 class TestNewResourceController(helpers.FunctionalTestBase):
 
     @classmethod
@@ -149,7 +150,6 @@ class TestDocumentationController(helpers.FunctionalTestBase):
     def test_dataset_tab_has_no_doc_resources(self):
         app = self._get_test_app()
         resp = app.get(url=url_for('/dataset/%s' % self.pkg), extra_environ=self.envs)
-        assert 'this-is-regular-resource' in resp, resp
         assert 'this-is-doc' not in resp
 
     def test_documentation_tab_has_work_ok_if_anonymous(self):

--- a/ckanext/ed/tests/test_controllers.py
+++ b/ckanext/ed/tests/test_controllers.py
@@ -190,25 +190,15 @@ class TestDocumentationController(helpers.FunctionalTestBase):
         resp = app.get(url=url_for('/dataset/docs/%s?edit=true' % self.pkg), extra_environ=self.envs)
         assert 'Explore' not in resp
 
-    def test_documentation_tab_has_pin_button(self):
+    def test_documentation_tab_has_pin_button_on_edit(self):
         app = self._get_test_app()
-        resp = app.get(url=url_for('/dataset/docs/%s' % self.pkg), extra_environ=self.envs)
+        resp = app.get(url=url_for('/dataset/docs/%s?edit=True' % self.pkg), extra_environ=self.envs)
         assert ' Pin' in resp
 
-    def test_documentation_tab_has_no_pin_button_for_anonymous(self):
+    def test_documentation_tab_has_unpin_button_on_edit(self):
         app = self._get_test_app()
-        resp = app.get(url=url_for('/dataset/docs/%s' % self.pkg))
-        assert ' Pin' not in resp
-
-    def test_documentation_tab_has_unpin_button(self):
-        app = self._get_test_app()
-        resp = app.get(url=url_for('/dataset/docs/%s' % self.pkg), extra_environ=self.envs)
+        resp = app.get(url=url_for('/dataset/docs/%s?edit=True' % self.pkg), extra_environ=self.envs)
         assert 'Unpin' in resp
-
-    def test_documentation_tab_has_no_unpin_button_for_anonymous(self):
-        app = self._get_test_app()
-        resp = app.get(url=url_for('/dataset/docs/%s' % self.pkg))
-        assert 'Unpin' not in resp
 
     def test_pin_works(self):
         pinned_res_id = None


### PR DESCRIPTION
PR enables to load resource page directly on dataset page.

- Uses query string `resoruce={resource_id}` to load the selected resource
- if no resource selected loads the first one

PR also includes modifications for docs page - fixes #165 