### PR TITLE
Fix URL for adding new data profile

### DIFF
--- a/ckanext/ed/templates/snippets/add_dataset.html
+++ b/ckanext/ed/templates/snippets/add_dataset.html
@@ -4,8 +4,6 @@
 
 {% if group %}
     {% link_for _('Add Data Profile'), controller='package', action='new', group=group, class_='usa-button usa-button--outline' %}
-{% elif dataset_type == 'dataset' %}
-    {% link_for _('Add Data Profile'), controller='package', action='new', group=group, class_='usa-button usa-button--outline' %}
 {% else %}
-    {% link_for _('Add ' + dataset_type.title()), controller='package', action='new', named_route=dataset_type + '_new', class_='usa-button usa-button--outline' %}
+    {% link_for _('Add Data Profile'), controller='package', action='new', named_route=dataset_type + '_new', class_='usa-button usa-button--outline' %}
 {% endif %}


### PR DESCRIPTION
The url for adding a new data profile was https://us-ed.l3.ckan.io/dataset/new?group=
which can cause problems with the form for adding a new Data Profile.
The ?group= is used when creating a Data Profile from a Provider, not want to create a dataset from the Search page.

This PR provides a fix for this and redirects to https://us-ed.l3.ckan.io/dataset/new

@tanvirchahal can you test this out locally and let me know how it goes?
